### PR TITLE
Adding unit tests for soritng dict

### DIFF
--- a/code/lib/seat_assign.py
+++ b/code/lib/seat_assign.py
@@ -16,7 +16,7 @@ class Seating:
         self.seats_per_row = 0
         self.total_seats = 0
 
-    def evens1st(seats):
+    def _evens1st(self, seats):
         num = seats[VALUE]
         # Test with modulus (%) two
         if num == 0:
@@ -47,7 +47,7 @@ class Seating:
         # 1: even numbers are first in asc order
         # 2: odd numbers are next in asc order
         # 3: negative numbers are next in desc order
-        seat_diff = sorted(avail_seats.items(), key=evens1st, reverse=True)
+        seat_diff = sorted(avail_seats.items(), key=self._evens1st, reverse=True)
         # Only interested in first element on sorted list
         # It is a tuple of set num and diff value
         return(seat_diff[0])

--- a/code/tests/test_input.py
+++ b/code/tests/test_input.py
@@ -4,15 +4,80 @@ from lib.seat_assign import Seating
 
 class TestInput(unittest.TestCase):
     def test_even_sort(self):
-        # Simple test list just to have test in framework
-        # input =  [7, 3, 4, 8, 1, 9, 14, 29, 0, -1, -8, -2]
+        """
+        Simple test list just to have test in framework
+        input =  [7, 3, 4, 8, 1, 9, 14, 29, 0, -1, -8, -2]
+        """
+        seating = Seating()
         input = {'1': 7, '2': 3, '4': 4, '5': 8, '6': 1, '7': 9, '8': 14,
                   '9': 29, '10': 0, '11': -1, '12': -8, '13': -2}
-        sorted_list = sorted(input.items(), key=Seating.evens1st, reverse=True)
-        result = [('10', 0), ('4', 4), ('5', 8), ('8', 14), ('6', 1), ('2', 3),
+        sorted_list = sorted(input.items(), key=seating._evens1st, reverse=True)
+        exp_result = [('10', 0), ('4', 4), ('5', 8), ('8', 14), ('6', 1), ('2', 3),
                   ('1', 7), ('7', 9), ('9', 29), ('11', -1), ('13', -2), ('12', -8)]
-        self.assertEqual(sorted_list, result)
+        self.assertEqual(sorted_list, exp_result)
 
+    def test_sort_dict_4_toget_r1(self):
+        """
+        Verify that the sort_dict method returns valid tuple combo when
+        there is adjacent number of seats available for booking group
+        i.e. group is able to be seated together
+        R|Seats
+        1|_ _ _ _
+        2|_ X _ _
+        3|_ X _ X
+        4|_ _ _ _
+        5|X _ _ _
+        For a new booking of 4 they should be seated in row 1
+        """
+        seating = Seating()
+        seat_nums = {1: 4, 5: 1, 7: 2, 9: 1, 11: 1, 13: 4, 18: 3}
+        group_num = 4
+        exp_result = (1, 0)
+        avail_seats = seating.sort_dict(seat_nums, group_num)
+        self.assertEqual(avail_seats, exp_result)
+
+
+    def test_sort_dict_3_toget_r4(self):
+        """
+        Verify that the sort_dict method returns valid tuple combo when
+        there is adjacent number of seats available for booking group
+        i.e. group is able to be seated together on line with 3 empty
+        seats (row 5 in this case)
+        R|Seats
+        1|_ X _ _
+        2|_ X _ _
+        3|_ _ _ _
+        4|_ _ _ _
+        5|X _ _ _
+        For a new booking of 4 they should be seated in row 4
+        """
+        seating = Seating()
+        seat_nums = {1: 1, 3: 2, 5: 1, 7: 2, 9: 4, 13: 4, 18: 3}
+        group_num = 3
+        exp_result = (18, 0)
+        avail_seats = seating.sort_dict(seat_nums, group_num)
+        self.assertEqual(avail_seats, exp_result)
+
+    def test_sort_dict_4_not_toget(self):
+        """
+        Verify that the sort_dict method returns valid tuple combo when
+        there is adjacent number of seats available for booking group
+        i.e. group is able to be seated together
+        R|Seats
+        1|_ X _ _
+        2|_ X _ _
+        3|_ _ X _
+        4|_ _ _ X
+        5|X _ _ _
+        For a new booking of 4 we should return negative number since
+        this indicates that there are no available adjacent seats
+        """
+        seating = Seating()
+        seat_nums = {1: 1, 3: 2, 5: 1, 7: 2, 9: 2, 11: 1, 13: 3, 18: 3}
+        group_num = 4
+        exp_result = (18, -1)
+        avail_seats = seating.sort_dict(seat_nums, group_num)
+        self.assertEqual(avail_seats, exp_result)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Adding tests to verify that sort dict returns correct tuple combo of seat num and available seats for 1/ case where there is empty row matching group booking, 2/ where there is partially full row with available adjacent seats which match booking number and 3/ where there is no adjacent number of seats available 